### PR TITLE
Add weights to cv.biglasso

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,10 +2,10 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 standardize_bm <- function(xP, row_idx_) {
-    .Call('biglasso_standardize_bm', PACKAGE = 'biglasso', xP, row_idx_)
+    .Call(`_biglasso_standardize_bm`, xP, row_idx_)
 }
 
 get_eta <- function(xP, row_idx_, beta, idx_p, idx_l) {
-    .Call('biglasso_get_eta', PACKAGE = 'biglasso', xP, row_idx_, beta, idx_p, idx_l)
+    .Call(`_biglasso_get_eta`, xP, row_idx_, beta, idx_p, idx_l)
 }
 

--- a/R/cv.biglasso.R
+++ b/R/cv.biglasso.R
@@ -181,6 +181,7 @@ cvf <- function(i, XX, y, eval.metric, cv.ind, cv.args, parallel= FALSE) {
   cv.args$X <- XX
   cv.args$y <- y
   cv.args$row.idx <- which(cv.ind != i)
+  cv.args$weights <- cv.args$weights[cv.args$row.idx]
   cv.args$warn <- FALSE
   cv.args$ncores <- 1
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -8,7 +8,7 @@ using namespace Rcpp;
 
 // standardize_bm
 RcppExport SEXP standardize_bm(SEXP xP, SEXP row_idx_);
-RcppExport SEXP biglasso_standardize_bm(SEXP xPSEXP, SEXP row_idx_SEXP) {
+RcppExport SEXP _biglasso_standardize_bm(SEXP xPSEXP, SEXP row_idx_SEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -20,7 +20,7 @@ END_RCPP
 }
 // get_eta
 RcppExport SEXP get_eta(SEXP xP, SEXP row_idx_, SEXP beta, SEXP idx_p, SEXP idx_l);
-RcppExport SEXP biglasso_get_eta(SEXP xPSEXP, SEXP row_idx_SEXP, SEXP betaSEXP, SEXP idx_pSEXP, SEXP idx_lSEXP) {
+RcppExport SEXP _biglasso_get_eta(SEXP xPSEXP, SEXP row_idx_SEXP, SEXP betaSEXP, SEXP idx_pSEXP, SEXP idx_lSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;

--- a/src/init.c
+++ b/src/init.c
@@ -141,7 +141,7 @@ extern SEXP cdfit_gaussian_hsr_bedpp_nac(SEXP X_, SEXP y_, SEXP row_idx_,
                                              SEXP safe_thresh_,
                                              SEXP verbose_);
 
-extern SEXP biglasso_get_eta(SEXP xPSEXP, SEXP row_idx_SEXP, SEXP betaSEXP, SEXP idx_pSEXP, SEXP idx_lSEXP);
+extern SEXP _biglasso_get_eta(SEXP xPSEXP, SEXP row_idx_SEXP, SEXP betaSEXP, SEXP idx_pSEXP, SEXP idx_lSEXP);
 
 static R_CallMethodDef callMethods[] = {
   {"cdfit_binomial_hsr", (DL_FUNC) &cdfit_binomial_hsr, 16},
@@ -162,7 +162,7 @@ static R_CallMethodDef callMethods[] = {
   {"cdfit_gaussian_edpp", (DL_FUNC) &cdfit_gaussian_edpp, 14},
   {"cdfit_gaussian_hsr_dome_nac", (DL_FUNC) &cdfit_gaussian_hsr_dome_nac, 16},
   {"cdfit_gaussian_hsr_bedpp_nac", (DL_FUNC) &cdfit_gaussian_hsr_bedpp_nac, 16},
-  {"biglasso_get_eta", (DL_FUNC) &biglasso_get_eta, 5},
+  {"_biglasso_get_eta", (DL_FUNC) &_biglasso_get_eta, 5},
   {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
In usage of the library with `weights`, I discovered weights weren't being passed to the `cv.biglasso` function. This PR plumbs weights to the fn. I plan to add a test case, but I wanted to share in the meantime.

Also, I ran into a C++ compilation issue. Apparently recent versions of `Rcpp` (> 1.0) prepend an underscore to exported fn names? This caused a conflict with a C++ file not managed by `Rcpp::compileAttributes()`, https://github.com/YaohuiZeng/biglasso/blob/cad0103ff5cd0ac0bdbcf0d28ec9b9f1e5da8577/src/init.c#L144 Adding the underscores fixes the compilation issue.