### PR TITLE
Switch Calloc,Free to R_Calloc,R_Free for STRICT_R_HEADERS

### DIFF
--- a/src/binomial.cpp
+++ b/src/binomial.cpp
@@ -259,13 +259,13 @@ RcppExport SEXP cdfit_binomial_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   double a0 = 0.0; //beta0 from previousiteration
-  double *w = Calloc(n, double);
-  double *s = Calloc(n, double); //y_i - pi_i
-  double *eta = Calloc(n, double);
-  int *e1 = Calloc(p, int); //ever-active set
-  int *e2 = Calloc(p, int); //strong set
+  double *w = R_Calloc(n, double);
+  double *s = R_Calloc(n, double); //y_i - pi_i
+  double *eta = R_Calloc(n, double);
+  int *e1 = R_Calloc(p, int); //ever-active set
+  int *e2 = R_Calloc(p, int); //strong set
   double xwr, xwx, pi, u, v, cutoff, l1, l2, shift, si;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart;
@@ -273,7 +273,7 @@ RcppExport SEXP cdfit_binomial_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   double ybar = sum(y, n) / n;
   a0 = beta0[0] = log(ybar / (1-ybar));
   double nullDev = 0;
-  double *r = Calloc(n, double);
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) {
     r[i] = y[i];
     nullDev = nullDev - y[i]*log(ybar) - (1-y[i])*log(1-ybar);
@@ -328,7 +328,7 @@ RcppExport SEXP cdfit_binomial_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
         return List::create(beta0, beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -385,7 +385,7 @@ RcppExport SEXP cdfit_binomial_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
           if (Dev[l] / nullDev < .01) {
             if (warn) warning("Model saturated; exiting...");
             for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-            Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+            R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
             return List::create(beta0, beta, center, scale, lambda, Dev,
                                 iter, n_reject, Rcpp::wrap(col_idx));
           }
@@ -441,7 +441,7 @@ RcppExport SEXP cdfit_binomial_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
   return List::create(beta0, beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
   
 }
@@ -518,13 +518,13 @@ RcppExport SEXP cdfit_binomial_ssr_approx(SEXP X_, SEXP y_, SEXP row_idx_,
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   double a0 = 0.0; //beta0 from previousiteration
-  double *w = Calloc(n, double);
-  double *s = Calloc(n, double); //y_i - pi_i
-  double *eta = Calloc(n, double);
-  int *e1 = Calloc(p, int); //ever-active set
-  int *e2 = Calloc(p, int); //strong set
+  double *w = R_Calloc(n, double);
+  double *s = R_Calloc(n, double); //y_i - pi_i
+  double *eta = R_Calloc(n, double);
+  int *e1 = R_Calloc(p, int); //ever-active set
+  int *e2 = R_Calloc(p, int); //strong set
   double xwr, xwx, pi, u, v, cutoff, l1, l2, shift, si;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart; // temp index
@@ -532,7 +532,7 @@ RcppExport SEXP cdfit_binomial_ssr_approx(SEXP X_, SEXP y_, SEXP row_idx_,
   double ybar = sum(y, n)/n;
   a0 = beta0[0] = log(ybar/(1-ybar));
   double nullDev = 0;
-  double *r = Calloc(n, double);
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) {
     r[i] = y[i];
     nullDev = nullDev - y[i] * log(ybar) - (1 - y[i]) * log(1 - ybar);
@@ -580,7 +580,7 @@ RcppExport SEXP cdfit_binomial_ssr_approx(SEXP X_, SEXP y_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
         return List::create(beta0, beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -634,7 +634,7 @@ RcppExport SEXP cdfit_binomial_ssr_approx(SEXP X_, SEXP y_, SEXP row_idx_,
           if (Dev[l] / nullDev < .01) {
             if (warn) warning("Model saturated; exiting...");
             for (int ll = l; ll < L; ll++) iter[ll] = NA_INTEGER;
-            Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+            R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
             return List::create(beta0, beta, center, scale, lambda, Dev, 
                                 iter, n_reject, Rcpp::wrap(col_idx));
           }
@@ -696,7 +696,7 @@ RcppExport SEXP cdfit_binomial_ssr_approx(SEXP X_, SEXP y_, SEXP row_idx_,
     }
   }
   
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
   return List::create(beta0, beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
 }
 
@@ -778,13 +778,13 @@ RcppExport SEXP cdfit_binomial_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEXP yl
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   double a0 = 0.0; //beta0 from previousiteration
-  double *w = Calloc(n, double);
-  double *s = Calloc(n, double); //y_i - pi_i
-  double *eta = Calloc(n, double);
-  int *e1 = Calloc(p, int); //ever-active set
-  int *e2 = Calloc(p, int); //strong set
+  double *w = R_Calloc(n, double);
+  double *s = R_Calloc(n, double); //y_i - pi_i
+  double *eta = R_Calloc(n, double);
+  int *e1 = R_Calloc(p, int); //ever-active set
+  int *e2 = R_Calloc(p, int); //strong set
   double xwr, xwx, pi, u, v, cutoff, l1, l2, shift, si;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart;
@@ -792,7 +792,7 @@ RcppExport SEXP cdfit_binomial_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEXP yl
   double ybar = sum(y, n) / n;
   a0 = beta0[0] = log(ybar / (1-ybar));
   double nullDev = 0;
-  double *r = Calloc(n, double);
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) {
     r[i] = y[i];
     nullDev = nullDev - y[i]*log(ybar) - (1-y[i])*log(1-ybar);
@@ -836,8 +836,8 @@ RcppExport SEXP cdfit_binomial_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEXP yl
   vector<double> X_theta_lam_xi_pos; 
   vector<double> prod_PX_Pxmax_xi_pos;
   vector<double> cutoff_xi_pos;
-  int *slores_reject = Calloc(p, int);
-  int *slores_reject_old = Calloc(p, int);
+  int *slores_reject = R_Calloc(p, int);
+  int *slores_reject_old = R_Calloc(p, int);
   for (int j = 0; j < p; j++) slores_reject_old[j] = 1;
   
   int slores; // if 0, don't perform Slores rule
@@ -877,8 +877,8 @@ RcppExport SEXP cdfit_binomial_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEXP yl
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(slores_reject); Free(slores_reject_old);
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+        R_Free(slores_reject); R_Free(slores_reject_old);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
         //ProfilerStop();
         return List::create(beta0, beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
@@ -952,8 +952,8 @@ RcppExport SEXP cdfit_binomial_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEXP yl
           if (Dev[l] / nullDev < .01) {
             if (warn) warning("Model saturated; exiting...");
             for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-            Free(slores_reject); Free(slores_reject_old);
-            Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+            R_Free(slores_reject); R_Free(slores_reject_old);
+            R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
             return List::create(beta0, beta, center, scale, lambda, Dev, iter, n_reject, n_slores_reject, Rcpp::wrap(col_idx));
           }
           // Intercept
@@ -1012,8 +1012,8 @@ RcppExport SEXP cdfit_binomial_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEXP yl
       }
     }
   }
-  Free(slores_reject); Free(slores_reject_old);
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+  R_Free(slores_reject); R_Free(slores_reject_old);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
   //ProfilerStop();
   return List::create(beta0, beta, center, scale, lambda, Dev, iter, n_reject, n_slores_reject, Rcpp::wrap(col_idx));
 }
@@ -1097,13 +1097,13 @@ RcppExport SEXP cdfit_binomial_ada_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEX
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   double a0 = 0.0; //beta0 from previousiteration
-  double *w = Calloc(n, double);
-  double *s = Calloc(n, double); //y_i - pi_i
-  double *eta = Calloc(n, double);
-  int *e1 = Calloc(p, int); //ever-active set
-  int *e2 = Calloc(p, int); //strong set
+  double *w = R_Calloc(n, double);
+  double *s = R_Calloc(n, double); //y_i - pi_i
+  double *eta = R_Calloc(n, double);
+  int *e1 = R_Calloc(p, int); //ever-active set
+  int *e2 = R_Calloc(p, int); //strong set
   double xwr, xwx, pi, u, v, cutoff, l1, l2, shift, si;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart;
@@ -1111,7 +1111,7 @@ RcppExport SEXP cdfit_binomial_ada_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEX
   double ybar = sum(y, n) / n;
   a0 = beta0[0] = log(ybar / (1-ybar));
   double nullDev = 0;
-  double *r = Calloc(n, double);
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) {
     r[i] = y[i];
     nullDev = nullDev - y[i]*log(ybar) - (1-y[i])*log(1-ybar);
@@ -1155,8 +1155,8 @@ RcppExport SEXP cdfit_binomial_ada_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEX
   vector<double> X_theta_lam_xi_pos; 
   vector<double> prod_PX_Pxmax_xi_pos;
   vector<double> cutoff_xi_pos;
-  int *slores_reject = Calloc(p, int);
-  int *slores_reject_old = Calloc(p, int);
+  int *slores_reject = R_Calloc(p, int);
+  int *slores_reject_old = R_Calloc(p, int);
   for (int j = 0; j < p; j++) slores_reject_old[j] = 1;
   int l_prev = lstart;
   double gain = 0.0;
@@ -1201,8 +1201,8 @@ RcppExport SEXP cdfit_binomial_ada_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEX
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(slores_reject); Free(slores_reject_old);
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+        R_Free(slores_reject); R_Free(slores_reject_old);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
         //ProfilerStop();
         return List::create(beta0, beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
@@ -1301,8 +1301,8 @@ RcppExport SEXP cdfit_binomial_ada_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEX
           if (Dev[l] / nullDev < .01) {
             if (warn) warning("Model saturated; exiting...");
             for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-            Free(slores_reject); Free(slores_reject_old);
-            Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+            R_Free(slores_reject); R_Free(slores_reject_old);
+            R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
             return List::create(beta0, beta, center, scale, lambda, Dev, iter, n_reject, n_slores_reject, Rcpp::wrap(col_idx));
           }
           // Intercept
@@ -1373,8 +1373,8 @@ RcppExport SEXP cdfit_binomial_ada_slores_ssr(SEXP X_, SEXP y_, SEXP n_pos_, SEX
        }*/
     }
   }
-  Free(slores_reject); Free(slores_reject_old);
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta);
+  R_Free(slores_reject); R_Free(slores_reject_old);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta);
   //ProfilerStop();
   return List::create(beta0, beta, center, scale, lambda, Dev, iter, n_reject, n_slores_reject, Rcpp::wrap(col_idx));
 }

--- a/src/cox.cpp
+++ b/src/cox.cpp
@@ -13,8 +13,8 @@ void standardize_and_get_residual_cox(NumericVector &center, NumericVector &scal
   double sum_xs;
   double zmax = 0.0, zj = 0.0;
   int i, j, k;
-  double *s = Calloc(n, double);
-  double *rsk = Calloc(f, double);
+  double *s = R_Calloc(n, double);
+  double *rsk = R_Calloc(f, double);
   
   rsk[0] = n;
   k = 0;
@@ -61,8 +61,8 @@ void standardize_and_get_residual_cox(NumericVector &center, NumericVector &scal
   }
   *p_keep_ptr = col_idx.size();
   *lambda_max_ptr = zmax / alpha;
-  Free(s);
-  Free(rsk);
+  R_Free(s);
+  R_Free(rsk);
 }
 
 // SAFE initialization
@@ -115,7 +115,7 @@ double dual_cox(double *haz, double *rsk, double lambda, double lambda_0,
                 int n, int f, double *y, double *d, int *d_idx) {
   double res = 0.0;
   double lam_ratio = lambda / lambda_0;
-  double *hlogh = Calloc(f, double);
+  double *hlogh = R_Calloc(f, double);
   int i, k;
   hlogh[f-1] = 0.0;
   k = f-1;
@@ -139,7 +139,7 @@ double dual_cox(double *haz, double *rsk, double lambda, double lambda_0,
         lam_ratio * d[k] * haz[i] / rsk[k] * log(lam_ratio * haz[i] / rsk[k]);
     } 
   }
-  Free(hlogh);
+  R_Free(hlogh);
   return res;
 }
 
@@ -212,8 +212,8 @@ void scox_update(vector<double>& X_theta_lam, vector<double>& z, double *eta,
     rsk0[k] += haz0[i];
   }
   
-  double *w = Calloc(n, double);
-  double *s = Calloc(n, double);
+  double *w = R_Calloc(n, double);
+  double *s = R_Calloc(n, double);
 
   //Rprintf("Old g = %f\n", dual_cox(haz0, rsk0, 1.0, 1.0, n, f, y, d, d_idx));
   //Rprintf("New g = %f\n", dual_cox(haz, rsk, 1.0, 1.0, n, f, y, d, d_idx));
@@ -262,7 +262,7 @@ void scox_update(vector<double>& X_theta_lam, vector<double>& z, double *eta,
     z[j] = sum_xs / (scale[jj] * n);
     X_theta_lam[j] = -z[j];
   }  
-  Free(s); Free(w);
+  R_Free(s); R_Free(w);
 
 }
 
@@ -275,11 +275,11 @@ void scox_updater(double *g_theta_lam_ptr, double *eta, double lambda, double l,
                   double alpha, double *a, arma::sp_mat& beta) {
   
   int i, j, jj, k;
-  double *haz = Calloc(n, double);
-  double *rsk = Calloc(f, double);
-  double *w = Calloc(n, double);
-  double *s = Calloc(n, double);
-  double *r = Calloc(n, double);
+  double *haz = R_Calloc(n, double);
+  double *rsk = R_Calloc(f, double);
+  double *w = R_Calloc(n, double);
+  double *s = R_Calloc(n, double);
+  double *r = R_Calloc(n, double);
   int iter = 0;
   double sumWResid, xwr, xwx, u, v, l1, l2, shift, update, max_update;
   
@@ -346,7 +346,7 @@ void scox_updater(double *g_theta_lam_ptr, double *eta, double lambda, double l,
   }
   
   *g_theta_lam_ptr = dual_cox(haz, rsk, 1.0, 1.0, n, f, y, d, d_idx);
-  Free(haz); Free(rsk); Free(r); Free(s); Free(w);
+  R_Free(haz); R_Free(rsk); R_Free(r); R_Free(s); R_Free(w);
   
 }
 
@@ -504,14 +504,14 @@ RcppExport SEXP cdfit_cox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_idx_,
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
-  double *w = Calloc(n, double); //weights from diagnal of hessian matrix
-  double *s = Calloc(n, double); //y_i - yhat_i
-  double *r = Calloc(n, double); //s/w
-  double *eta = Calloc(n, double); //X\beta
-  double *haz = Calloc(n, double); //exp(eta)
-  double *rsk = Calloc(f, double); //Sum of hazard over at risk set
-  int *e1 = Calloc(p, int); //ever-active set
+  double *a = R_Calloc(p, double); //Beta from previous iteration
+  double *w = R_Calloc(n, double); //weights from diagnal of hessian matrix
+  double *s = R_Calloc(n, double); //y_i - yhat_i
+  double *r = R_Calloc(n, double); //s/w
+  double *eta = R_Calloc(n, double); //X\beta
+  double *haz = R_Calloc(n, double); //exp(eta)
+  double *rsk = R_Calloc(f, double); //Sum of hazard over at risk set
+  int *e1 = R_Calloc(p, int); //ever-active set
   double xwr, xwx, u, v, l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, k, l, violations, lstart;
@@ -581,7 +581,7 @@ RcppExport SEXP cdfit_cox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(eta); Free(haz); Free(rsk);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(eta); R_Free(haz); R_Free(rsk);
         return List::create(beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -612,7 +612,7 @@ RcppExport SEXP cdfit_cox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_idx_,
         if (Dev[l] / nullDev < .01) {
           if (warn) warning("Model saturated with deviance %f; exiting...", Dev[l]);
           for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-          Free(s); Free(w); Free(a); Free(r); Free(e1); Free(eta); Free(haz); Free(rsk);
+          R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(eta); R_Free(haz); R_Free(rsk);
           return List::create(beta, center, scale, lambda, Dev,
                               iter, n_reject, Rcpp::wrap(col_idx));
         }
@@ -667,7 +667,7 @@ RcppExport SEXP cdfit_cox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_idx_,
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(eta); Free(haz); Free(rsk);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(eta); R_Free(haz); R_Free(rsk);
   return List::create(beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
   
 }
@@ -745,15 +745,15 @@ RcppExport SEXP cdfit_cox_ssr(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_i
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
-  double *w = Calloc(n, double); //weights from diagnal of hessian matrix
-  double *s = Calloc(n, double); //y_i - yhat_i
-  double *r = Calloc(n, double); //s/w
-  double *eta = Calloc(n, double); //X\beta
-  double *haz = Calloc(n, double); //exp(eta)
-  double *rsk = Calloc(f, double); //Sum of hazard over at risk set
-  int *e1 = Calloc(p, int); //ever-active set
-  int *e2 = Calloc(p, int); //strong set
+  double *a = R_Calloc(p, double); //Beta from previous iteration
+  double *w = R_Calloc(n, double); //weights from diagnal of hessian matrix
+  double *s = R_Calloc(n, double); //y_i - yhat_i
+  double *r = R_Calloc(n, double); //s/w
+  double *eta = R_Calloc(n, double); //X\beta
+  double *haz = R_Calloc(n, double); //exp(eta)
+  double *rsk = R_Calloc(f, double); //Sum of hazard over at risk set
+  int *e1 = R_Calloc(p, int); //ever-active set
+  int *e2 = R_Calloc(p, int); //strong set
   double xwr, xwx, u, v, cutoff, l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, k, l, violations, lstart;
@@ -824,7 +824,7 @@ RcppExport SEXP cdfit_cox_ssr(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_i
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta); Free(haz); Free(rsk);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta); R_Free(haz); R_Free(rsk);
         return List::create(beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -878,7 +878,7 @@ RcppExport SEXP cdfit_cox_ssr(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_i
           if (Dev[l] / nullDev < .01) {
             if (warn) warning("Model saturated with deviance %f; exiting...", Dev[l]);
             for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-            Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta); Free(haz); Free(rsk);
+            R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta); R_Free(haz); R_Free(rsk);
             return List::create(beta, center, scale, lambda, Dev,
                                 iter, n_reject, Rcpp::wrap(col_idx));
           }
@@ -937,7 +937,7 @@ RcppExport SEXP cdfit_cox_ssr(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_i
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(eta); Free(haz); Free(rsk);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(eta); R_Free(haz); R_Free(rsk);
   return List::create(beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
   
 }
@@ -1016,14 +1016,14 @@ RcppExport SEXP cdfit_cox_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
-  double *w = Calloc(n, double); //weights from diagnal of hessian matrix
-  double *s = Calloc(n, double); //y_i - yhat_i
-  double *r = Calloc(n, double); //s/w
-  double *eta = Calloc(n, double); //X\beta
-  double *haz = Calloc(n, double); //exp(eta)
-  double *rsk = Calloc(f, double); //Sum of hazard over at risk set
-  int *e1 = Calloc(p, int); //ever-active set
+  double *a = R_Calloc(p, double); //Beta from previous iteration
+  double *w = R_Calloc(n, double); //weights from diagnal of hessian matrix
+  double *s = R_Calloc(n, double); //y_i - yhat_i
+  double *r = R_Calloc(n, double); //s/w
+  double *eta = R_Calloc(n, double); //X\beta
+  double *haz = R_Calloc(n, double); //exp(eta)
+  double *rsk = R_Calloc(f, double); //Sum of hazard over at risk set
+  int *e1 = R_Calloc(p, int); //ever-active set
   double xwr, xwx, u, v, cutoff, l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, k, l, violations, lstart;
@@ -1083,9 +1083,9 @@ RcppExport SEXP cdfit_cox_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
   double *g_theta_lam_ptr = &g_theta_lam;
   vector<double> X_theta_lam; 
   vector<double> scaleP_X;
-  int *safe_reject = Calloc(p, int);
-  double *haz0 = Calloc(n, double);
-  double *rsk0 = Calloc(f, double);
+  int *safe_reject = R_Calloc(p, int);
+  double *haz0 = R_Calloc(n, double);
+  double *rsk0 = R_Calloc(f, double);
   
   int scox; // if 0, don't perform Scox rule
   if (safe_thresh < 1) {
@@ -1122,7 +1122,7 @@ RcppExport SEXP cdfit_cox_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
         return List::create(beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -1159,7 +1159,7 @@ RcppExport SEXP cdfit_cox_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
         if (Dev[l] / nullDev < .01) {
           if (warn) warning("Model saturated with deviance %f; exiting...", Dev[l]);
           for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-          Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+          R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
           return List::create(beta, center, scale, lambda, Dev,
                               iter, n_reject, Rcpp::wrap(col_idx));
         }
@@ -1214,7 +1214,7 @@ RcppExport SEXP cdfit_cox_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
   return List::create(beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
 }
 
@@ -1292,14 +1292,14 @@ RcppExport SEXP cdfit_cox_sscox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
-  double *w = Calloc(n, double); //weights from diagnal of hessian matrix
-  double *s = Calloc(n, double); //y_i - yhat_i
-  double *r = Calloc(n, double); //s/w
-  double *eta = Calloc(n, double); //X\beta
-  double *haz = Calloc(n, double); //exp(eta)
-  double *rsk = Calloc(f, double); //Sum of hazard over at risk set
-  int *e1 = Calloc(p, int); //ever-active set
+  double *a = R_Calloc(p, double); //Beta from previous iteration
+  double *w = R_Calloc(n, double); //weights from diagnal of hessian matrix
+  double *s = R_Calloc(n, double); //y_i - yhat_i
+  double *r = R_Calloc(n, double); //s/w
+  double *eta = R_Calloc(n, double); //X\beta
+  double *haz = R_Calloc(n, double); //exp(eta)
+  double *rsk = R_Calloc(f, double); //Sum of hazard over at risk set
+  int *e1 = R_Calloc(p, int); //ever-active set
   double xwr, xwx, u, v, cutoff, l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, k, l, violations, lstart;
@@ -1359,9 +1359,9 @@ RcppExport SEXP cdfit_cox_sscox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row
   double *g_theta_lam_ptr = &g_theta_lam;
   vector<double> X_theta_lam; 
   vector<double> scaleP_X;
-  double *haz0 = Calloc(n, double);
-  double *rsk0 = Calloc(f, double);
-  int *safe_reject = Calloc(p, int);
+  double *haz0 = R_Calloc(n, double);
+  double *rsk0 = R_Calloc(f, double);
+  int *safe_reject = R_Calloc(p, int);
   
 
   int scox; // if 0, don't perform Scox rule
@@ -1399,7 +1399,7 @@ RcppExport SEXP cdfit_cox_sscox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
         return List::create(beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -1444,7 +1444,7 @@ RcppExport SEXP cdfit_cox_sscox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row
         if (Dev[l] / nullDev < .01) {
           if (warn) warning("Model saturated with deviance %f; exiting...", Dev[l]);
           for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-          Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+          R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
           return List::create(beta, center, scale, lambda, Dev,
                               iter, n_reject, Rcpp::wrap(col_idx));
         }
@@ -1500,7 +1500,7 @@ RcppExport SEXP cdfit_cox_sscox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
   return List::create(beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
 }
 
@@ -1581,15 +1581,15 @@ RcppExport SEXP cdfit_cox_ada_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP 
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
-  double *w = Calloc(n, double); //weights from diagnal of hessian matrix
-  double *s = Calloc(n, double); //y_i - yhat_i
-  double *r = Calloc(n, double); //s/w
-  double *eta = Calloc(n, double); //X\beta
-  double *haz = Calloc(n, double); //exp(eta)
-  double *rsk = Calloc(f, double); //Sum of hazard over at risk set
-  int *e1 = Calloc(p, int); //ever-active set
-  int *e2 = Calloc(p, int); //strong set
+  double *a = R_Calloc(p, double); //Beta from previous iteration
+  double *w = R_Calloc(n, double); //weights from diagnal of hessian matrix
+  double *s = R_Calloc(n, double); //y_i - yhat_i
+  double *r = R_Calloc(n, double); //s/w
+  double *eta = R_Calloc(n, double); //X\beta
+  double *haz = R_Calloc(n, double); //exp(eta)
+  double *rsk = R_Calloc(f, double); //Sum of hazard over at risk set
+  int *e1 = R_Calloc(p, int); //ever-active set
+  int *e2 = R_Calloc(p, int); //strong set
   double xwr, xwx, u, v, cutoff, l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, k, l, violations, lstart;
@@ -1650,9 +1650,9 @@ RcppExport SEXP cdfit_cox_ada_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP 
   double *g_theta_lam_ptr = &g_theta_lam;
   vector<double> X_theta_lam; 
   vector<double> scaleP_X;
-  double *haz0 = Calloc(n, double);
-  double *rsk0 = Calloc(f, double);
-  int *safe_reject = Calloc(p, int);
+  double *haz0 = R_Calloc(n, double);
+  double *rsk0 = R_Calloc(f, double);
+  int *safe_reject = R_Calloc(p, int);
   int gain = 0;
   int l_prev = lstart;
   
@@ -1692,7 +1692,7 @@ RcppExport SEXP cdfit_cox_ada_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP 
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
         return List::create(beta, center, scale, lambda, Dev, iter,
                             n_reject, n_safe_reject, Rcpp::wrap(col_idx));
       }
@@ -1763,7 +1763,7 @@ RcppExport SEXP cdfit_cox_ada_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP 
           if (Dev[l] / nullDev < .01) {
             if (warn) warning("Model saturated with deviance %f; exiting...", Dev[l]);
             for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-            Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+            R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
             return List::create(beta, center, scale, lambda, Dev, iter,
                                 n_reject, n_safe_reject, Rcpp::wrap(col_idx));
           }
@@ -1824,7 +1824,7 @@ RcppExport SEXP cdfit_cox_ada_scox(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP 
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(e2); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
   return List::create(beta, center, scale, lambda, Dev, iter, n_reject, n_safe_reject, Rcpp::wrap(col_idx));
 }
 // Coordinate descent for cox models with SAFE
@@ -1901,14 +1901,14 @@ RcppExport SEXP cdfit_cox_safe(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
   }
   
   arma::sp_mat beta = arma::sp_mat(p, L); //beta
-  double *a = Calloc(p, double); //Beta from previous iteration
-  double *w = Calloc(n, double); //weights from diagnal of hessian matrix
-  double *s = Calloc(n, double); //y_i - yhat_i
-  double *r = Calloc(n, double); //s/w
-  double *eta = Calloc(n, double); //X\beta
-  double *haz = Calloc(n, double); //exp(eta)
-  double *rsk = Calloc(f, double); //Sum of hazard over at risk set
-  int *e1 = Calloc(p, int); //ever-active set
+  double *a = R_Calloc(p, double); //Beta from previous iteration
+  double *w = R_Calloc(n, double); //weights from diagnal of hessian matrix
+  double *s = R_Calloc(n, double); //y_i - yhat_i
+  double *r = R_Calloc(n, double); //s/w
+  double *eta = R_Calloc(n, double); //X\beta
+  double *haz = R_Calloc(n, double); //exp(eta)
+  double *rsk = R_Calloc(f, double); //Sum of hazard over at risk set
+  int *e1 = R_Calloc(p, int); //ever-active set
   double xwr, xwx, u, v, cutoff, l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, k, l, violations, lstart;
@@ -1965,7 +1965,7 @@ RcppExport SEXP cdfit_cox_safe(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
   
   // SAFE variables
   vector<double> scale_SAFE_X;
-  int *safe_reject = Calloc(p, int);
+  int *safe_reject = R_Calloc(p, int);
   
   int scox; // if 0, don't perform SAFE rule
   if (safe_thresh < 1) {
@@ -1999,7 +1999,7 @@ RcppExport SEXP cdfit_cox_safe(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+        R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
         return List::create(beta, center, scale, lambda, Dev, 
                             iter, n_reject, Rcpp::wrap(col_idx));
       }
@@ -2034,7 +2034,7 @@ RcppExport SEXP cdfit_cox_safe(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
         if (Dev[l] / nullDev < .01) {
           if (warn) warning("Model saturated with deviance %f; exiting...", Dev[l]);
           for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-          Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+          R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
           return List::create(beta, center, scale, lambda, Dev,
                               iter, n_reject, Rcpp::wrap(col_idx));
         }
@@ -2086,6 +2086,6 @@ RcppExport SEXP cdfit_cox_safe(SEXP X_, SEXP y_, SEXP d_, SEXP d_idx_, SEXP row_
       if (violations==0) break;
     }
   }
-  Free(s); Free(w); Free(a); Free(r); Free(e1); Free(safe_reject); Free(eta); Free(haz); Free(rsk);
+  R_Free(s); R_Free(w); R_Free(a); R_Free(r); R_Free(e1); R_Free(safe_reject); R_Free(eta); R_Free(haz); R_Free(rsk);
   return List::create(beta, center, scale, lambda, Dev, iter, n_reject, Rcpp::wrap(col_idx));
 }

--- a/src/gaussian.cpp
+++ b/src/gaussian.cpp
@@ -158,7 +158,7 @@ RcppExport SEXP cdfit_gaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   
   // Objects to be returned to R
   arma::sp_mat beta = arma::sp_mat(p, L); // beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   NumericVector loss(L);
   IntegerVector iter(L);
   IntegerVector n_reject(L);
@@ -166,9 +166,9 @@ RcppExport SEXP cdfit_gaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   double l1, l2, cutoff, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart;
-  int *e1 = Calloc(p, int); // ever active set
-  int *e2 = Calloc(p, int); // strong set
-  double *r = Calloc(n, double);
+  int *e1 = R_Calloc(p, int); // ever active set
+  int *e2 = R_Calloc(p, int); // strong set
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) r[i] = y[i];
   double sumResid = sum(r, n);
   loss[0] = gLoss(r,n);
@@ -214,7 +214,7 @@ RcppExport SEXP cdfit_gaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(a); Free(r); Free(e1); Free(e2);
+        R_Free(a); R_Free(r); R_Free(e1); R_Free(e2);
         return List::create(beta, center, scale, lambda, loss, iter, n_reject, Rcpp::wrap(col_idx));
       }
       // strong set
@@ -286,7 +286,7 @@ RcppExport SEXP cdfit_gaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
     }
   }
   
-  Free(a); Free(r); Free(e1); Free(e2);
+  R_Free(a); R_Free(r); R_Free(e1); R_Free(e2);
   return List::create(beta, center, scale, lambda, loss, iter, n_reject, Rcpp::wrap(col_idx));
 }
 
@@ -362,7 +362,7 @@ RcppExport SEXP cdfit_gaussian_ada_edpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_, SEX
   
   // Objects to be returned to R
   arma::sp_mat beta = arma::sp_mat(p, L); //Beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   NumericVector loss(L);
   IntegerVector iter(L);
   IntegerVector n_reject(L);
@@ -371,11 +371,11 @@ RcppExport SEXP cdfit_gaussian_ada_edpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_, SEX
   double l1, l2, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart; //temp index
-  int *ever_active = Calloc(p, int); // ever-active set
-  int *strong_set = Calloc(p, int); // strong set
-  int *discard_beta = Calloc(p, int); // index set of discarded features;
-  //int *discard_old = Calloc(p, int);
-  double *r = Calloc(n, double);
+  int *ever_active = R_Calloc(p, int); // ever-active set
+  int *strong_set = R_Calloc(p, int); // strong set
+  int *discard_beta = R_Calloc(p, int); // index set of discarded features;
+  //int *discard_old = R_Calloc(p, int);
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) r[i] = y[i];
   double sumResid = sum(r, n);
   loss[0] = gLoss(r, n);
@@ -383,15 +383,15 @@ RcppExport SEXP cdfit_gaussian_ada_edpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_, SEX
   
   // EDPP
   double c;
-  double *lhs2 = Calloc(p, double); //Second term on LHS
+  double *lhs2 = R_Calloc(p, double); //Second term on LHS
   double rhs2 = 0.0; // second term on RHS
-  double *Xty = Calloc(p, double);
-  double *Xtr = Calloc(p, double); // Xtr at previous update of EDPP
+  double *Xty = R_Calloc(p, double);
+  double *Xtr = R_Calloc(p, double); // Xtr at previous update of EDPP
   for(j = 0; j < p; j++) {
     Xty[j] = z[j] * n;
     Xtr[j] = Xty[j];
   }
-  double *yhat = Calloc(n, double); // yhat at previous rupdate of EDPP
+  double *yhat = R_Calloc(n, double); // yhat at previous rupdate of EDPP
   double yhat_norm2;
   double ytyhat;
   double y_norm2 = 0; // ||y||^2
@@ -448,7 +448,7 @@ RcppExport SEXP cdfit_gaussian_ada_edpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_, SEX
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(ever_active); Free(r); Free(a); Free(discard_beta); Free(lhs2); Free(Xty); Free(Xtr); Free(yhat); Free(strong_set); //Free(discard_old); 
+        R_Free(ever_active); R_Free(r); R_Free(a); R_Free(discard_beta); R_Free(lhs2); R_Free(Xty); R_Free(Xtr); R_Free(yhat); R_Free(strong_set); //R_Free(discard_old); 
         return List::create(beta, center, scale, lambda, loss, iter,  n_reject, n_safe_reject, Rcpp::wrap(col_idx));
       }
       if(gain - n_safe_reject[l - 1] * (l - l_prev) > update_thresh * p && l != L - 1) { // Update EDPP if not discarding enough
@@ -593,7 +593,7 @@ RcppExport SEXP cdfit_gaussian_ada_edpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_, SEX
     }
   }
   
-  Free(ever_active); Free(r); Free(a); Free(discard_beta); Free(lhs2); Free(Xty); Free(Xtr); Free(yhat); Free(strong_set); //Free(discard_old);
+  R_Free(ever_active); R_Free(r); R_Free(a); R_Free(discard_beta); R_Free(lhs2); R_Free(Xty); R_Free(Xtr); R_Free(yhat); R_Free(strong_set); //R_Free(discard_old);
   //ProfilerStop();
   return List::create(beta, center, scale, lambda, loss, iter, n_reject, n_safe_reject, Rcpp::wrap(col_idx));
 }
@@ -672,7 +672,7 @@ RcppExport SEXP cdfit_gaussian_bedpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   
   // Objects to be returned to R
   arma::sp_mat beta = arma::sp_mat(p, L); // Beta
-  double *a = Calloc(p, double); //Beta from previous iteration
+  double *a = R_Calloc(p, double); //Beta from previous iteration
   NumericVector loss(L);
   IntegerVector iter(L);
   IntegerVector n_reject(L); // number of total rejections;
@@ -681,9 +681,9 @@ RcppExport SEXP cdfit_gaussian_bedpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   double l1, l2, cutoff, shift;
   double max_update, update, thresh; // for convergence check
   int i, j, jj, l, violations, lstart; 
-  int *e1 = Calloc(p, int); // ever-active set
-  int *e2 = Calloc(p, int); // strong set
-  double *r = Calloc(n, double);
+  int *e1 = R_Calloc(p, int); // ever-active set
+  int *e2 = R_Calloc(p, int); // strong set
+  double *r = R_Calloc(n, double);
   for (i = 0; i < n; i++) r[i] = y[i];
   double sumResid = sum(r, n);
   loss[0] = gLoss(r,n);
@@ -716,8 +716,8 @@ RcppExport SEXP cdfit_gaussian_bedpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   vector<double> xty;
   vector<double> sign_lammax_xtxmax;
   double ynorm_sq = 0;
-  int *bedpp_reject = Calloc(p, int);
-  int *bedpp_reject_old = Calloc(p, int);
+  int *bedpp_reject = R_Calloc(p, int);
+  int *bedpp_reject_old = R_Calloc(p, int);
   int bedpp; // if 0, don't perform bedpp test
   if (bedpp_thresh < 1) {
     bedpp = 1; // turn on bedpp test
@@ -752,7 +752,7 @@ RcppExport SEXP cdfit_gaussian_bedpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll = l; ll < L; ll++) iter[ll] = NA_INTEGER;
-        Free(a); Free(r); Free(e1); Free(e2); Free(bedpp_reject); Free(bedpp_reject_old);
+        R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(bedpp_reject); R_Free(bedpp_reject_old);
         return List::create(beta, center, scale, lambda, loss, iter, 
                             n_reject, n_bedpp_reject, Rcpp::wrap(col_idx));
       }
@@ -849,7 +849,7 @@ RcppExport SEXP cdfit_gaussian_bedpp_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
     }
   }
   
-  Free(a); Free(r); Free(e1); Free(e2); Free(bedpp_reject); Free(bedpp_reject_old);
+  R_Free(a); R_Free(r); R_Free(e1); R_Free(e2); R_Free(bedpp_reject); R_Free(bedpp_reject_old);
   //ProfilerStop();
   return List::create(beta, center, scale, lambda, loss, iter, n_reject, n_bedpp_reject, Rcpp::wrap(col_idx));
 }

--- a/src/mgaussian.cpp
+++ b/src/mgaussian.cpp
@@ -10,8 +10,8 @@ void standardize_and_get_residual(NumericVector &center, NumericVector &scale,
                                   double alpha, int n, int p, int m) {
   MatrixAccessor<double> xAcc(*xMat);
   double *xCol;
-  double *sum_xy = Calloc(m, double);
-  double *sum_y = Calloc(m, double);
+  double *sum_xy = R_Calloc(m, double);
+  double *sum_y = R_Calloc(m, double);
   double zmax = 0.0, zj = 0.0;
   int i, j, k;
   
@@ -55,7 +55,7 @@ void standardize_and_get_residual(NumericVector &center, NumericVector &scale,
   }
   *p_keep_ptr = col_idx.size();
   *lambda_max_ptr = zmax / alpha;
-  Free(sum_xy); Free(sum_y);
+  R_Free(sum_xy); R_Free(sum_y);
 }
 
 // standardize for multiresponse and store XtY
@@ -68,8 +68,8 @@ void standardize_and_get_residual(NumericVector &center, NumericVector &scale,
                                   int n, int p, int m) {
   MatrixAccessor<double> xAcc(*xMat);
   double *xCol;
-  double *sum_xy = Calloc(m, double);
-  double *sum_y = Calloc(m, double);
+  double *sum_xy = R_Calloc(m, double);
+  double *sum_y = R_Calloc(m, double);
   double zmax = 0.0, zj = 0.0;
   int i, j, k;
   
@@ -114,7 +114,7 @@ void standardize_and_get_residual(NumericVector &center, NumericVector &scale,
   }
   *p_keep_ptr = col_idx.size();
   *lambda_max_ptr = zmax / alpha;
-  Free(sum_xy); Free(sum_y);
+  R_Free(sum_xy); R_Free(sum_y);
 }
 
 // Crossproduct xjTR
@@ -175,7 +175,7 @@ void bedpp_init(XPtr<BigMatrix> xMat, double *R, double *sumResid, vector<double
                 int n, int p, int m) {
   double xjtx; // xjtx_max
   // compute x_maxtY
-  double *xTR = Calloc(m, double);
+  double *xTR = R_Calloc(m, double);
   int j, jj, k;
   crossprod_resid(xTR, xMat, R, sumResid, row_idx,
                   center[xmax_idx], scale[xmax_idx], n, m, xmax_idx);
@@ -191,7 +191,7 @@ void bedpp_init(XPtr<BigMatrix> xMat, double *R, double *sumResid, vector<double
     }
     lhs3[j] *= xjtx / n;
   }
-  Free(xTR);
+  R_Free(xTR);
 }
 
 // apply EDPP 
@@ -226,7 +226,7 @@ void edpp_update(XPtr<BigMatrix> xpMat, double *R, double *sumResid,
   for(j = 0; j < p; j++){
     jj = col_idx[j];
     xCol = xAcc[jj];
-    xTR = Calloc(m, double);
+    xTR = R_Calloc(m, double);
     for(k = 0; k < m; k++) xTR[k] = 0;
     sum2 = 0.0;
     sum3 = 0.0;
@@ -241,7 +241,7 @@ void edpp_update(XPtr<BigMatrix> xpMat, double *R, double *sumResid,
     } 
     lhs2[j] = sum2;
     lhs3[j] = sum3;
-    Free(xTR);
+    R_Free(xTR);
   }
 }
 
@@ -262,7 +262,7 @@ int check_strong_set(int *e1, int *e2, vector<double> &z, XPtr<BigMatrix> xpMat,
       xCol = xAcc[jj];
       z[j] = 0.0;
       sum = 0.0;
-      xTR = Calloc(m, double);
+      xTR = R_Calloc(m, double);
       for(k=0; k < m; k++) xTR[k] = 0.0;
       for (i=0; i < n; i++) {
         for (k=0; k < m; k++) {
@@ -281,7 +281,7 @@ int check_strong_set(int *e1, int *e2, vector<double> &z, XPtr<BigMatrix> xpMat,
         e1[j] = 1;
         violations++;
       }
-      Free(xTR);
+      R_Free(xTR);
     }
   }
   return violations;
@@ -303,7 +303,7 @@ int check_rest_set(int *e1, int *e2, vector<double> &z, XPtr<BigMatrix> xpMat,
       xCol = xAcc[jj];
       z[j] = 0.0;
       sum = 0.0;
-      xTR = Calloc(m, double);
+      xTR = R_Calloc(m, double);
       for(k=0; k < m; k++) xTR[k] = 0.0;
       for (i=0; i < n; i++) {
         for (k=0; k < m; k++) {
@@ -322,7 +322,7 @@ int check_rest_set(int *e1, int *e2, vector<double> &z, XPtr<BigMatrix> xpMat,
         e1[j] = e2[j] = 1;
         violations++;
       }
-      Free(xTR);
+      R_Free(xTR);
     }
   }
   return violations;
@@ -345,7 +345,7 @@ int check_rest_safe_set(int *e1, int *e2, int *discard_beta, vector<double> &z,
       xCol = xAcc[jj];
       z[j] = 0.0;
       sum = 0.0;
-      xTR = Calloc(m, double);
+      xTR = R_Calloc(m, double);
       for(k=0; k < m; k++) xTR[k] = 0.0;
       for (i=0; i < n; i++) {
         for (k=0; k < m; k++) {
@@ -364,7 +364,7 @@ int check_rest_safe_set(int *e1, int *e2, int *discard_beta, vector<double> &z,
         e1[j] = e2[j] = 1;
         violations++;
       }
-      Free(xTR);
+      R_Free(xTR);
     }
   }
   return violations;
@@ -451,20 +451,20 @@ RcppExport SEXP cdfit_mgaussian_ada(SEXP X_, SEXP y_, SEXP row_idx_,
   arma::field<arma::sp_mat> beta(m);
   beta.for_each( [&](arma::sp_mat& beta_class) { beta_class.set_size(p, L); } );
   //arma::sp_mat beta = arma::sp_mat(m*p, L); // beta
-  double *a = Calloc(m*p, double); //Beta from previous iteration
+  double *a = R_Calloc(m*p, double); //Beta from previous iteration
   NumericVector loss(L);
   IntegerVector iter(L);
   IntegerVector n_reject(L);
   
   double l1, l2, cutoff, cutoff0;
-  double* shift = Calloc(m, double);
+  double* shift = R_Calloc(m, double);
   double max_update, update, thresh; // for convergence check
   int i, j, k, jj, l, violations, lstart;
   
-  int *e1 = Calloc(p, int); // ever active set
-  int *e2 = Calloc(p, int); // strong set
-  double *R = Calloc(m*n, double); // residual matrix
-  double *sumResid = Calloc(m, double);
+  int *e1 = R_Calloc(p, int); // ever active set
+  int *e2 = R_Calloc(p, int); // strong set
+  double *R = R_Calloc(m*n, double); // residual matrix
+  double *sumResid = R_Calloc(m, double);
   loss[0] = 0.0;
   for(k = 0; k < m; k++) sumResid[k] = 0.0;
   for(i = 0; i < n; i++) {
@@ -474,15 +474,15 @@ RcppExport SEXP cdfit_mgaussian_ada(SEXP X_, SEXP y_, SEXP row_idx_,
       loss[0] += pow(Y.at(k, i), 2);
     } 
   }
-  double *xTR = Calloc(m, double);
+  double *xTR = R_Calloc(m, double);
   thresh = eps * loss[0] / n;
   
   // EDPP
-  int *discard_beta = Calloc(p, int); // index set of discarded features;
+  int *discard_beta = R_Calloc(p, int); // index set of discarded features;
   double c, d;
-  double *lhs1 = Calloc(p, double); // 1st term on LHS, ||XTY||_2
-  double *lhs2 = Calloc(p, double); // 2nd term on LHS, ||XTR||_2 if EDPP
-  double *lhs3 = Calloc(p, double); // 3rd term on LHS, <XTY,XTR> if EDPP
+  double *lhs1 = R_Calloc(p, double); // 1st term on LHS, ||XTY||_2
+  double *lhs2 = R_Calloc(p, double); // 2nd term on LHS, ||XTR||_2 if EDPP
+  double *lhs3 = R_Calloc(p, double); // 3rd term on LHS, <XTY,XTR> if EDPP
   double rhs2 = 0.0; // second term on RHS
   double yhat;
   double Yhat_norm2 = 0.0;
@@ -538,8 +538,8 @@ RcppExport SEXP cdfit_mgaussian_ada(SEXP X_, SEXP y_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(a); Free(e1); Free(e2); Free(xTR); Free(shift); Free(R); Free(sumResid);
-        Free(discard_beta); Free(lhs1); Free(lhs2); Free(lhs3);
+        R_Free(a); R_Free(e1); R_Free(e2); R_Free(xTR); R_Free(shift); R_Free(R); R_Free(sumResid);
+        R_Free(discard_beta); R_Free(lhs1); R_Free(lhs2); R_Free(lhs3);
         return List::create(beta, center, scale, lambda, loss, iter, 
                             n_reject, n_safe_reject, Rcpp::wrap(col_idx));
       }
@@ -708,8 +708,8 @@ RcppExport SEXP cdfit_mgaussian_ada(SEXP X_, SEXP y_, SEXP row_idx_,
     }
   }
   
-  Free(a); Free(e1); Free(e2); Free(xTR); Free(shift); Free(R); Free(sumResid);
-  Free(discard_beta); Free(lhs1); Free(lhs2); Free(lhs3);
+  R_Free(a); R_Free(e1); R_Free(e2); R_Free(xTR); R_Free(shift); R_Free(R); R_Free(sumResid);
+  R_Free(discard_beta); R_Free(lhs1); R_Free(lhs2); R_Free(lhs3);
   //ProfilerStop();
   return List::create(beta, center, scale, lambda, loss, iter,
                       n_reject, n_safe_reject, Rcpp::wrap(col_idx));
@@ -790,20 +790,20 @@ RcppExport SEXP cdfit_mgaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
   arma::field<arma::sp_mat> beta(m);
   beta.for_each( [&](arma::sp_mat& beta_class) { beta_class.set_size(p, L); } );
   //arma::sp_mat beta = arma::sp_mat(m*p, L); // beta
-  double *a = Calloc(m*p, double); //Beta from previous iteration
+  double *a = R_Calloc(m*p, double); //Beta from previous iteration
   NumericVector loss(L);
   IntegerVector iter(L);
   IntegerVector n_reject(L);
   
   double l1, l2, cutoff;
-  double* shift = Calloc(m, double);
+  double* shift = R_Calloc(m, double);
   double max_update, update, thresh; // for convergence check
   int i, j, k, jj, l, violations, lstart;
   
-  int *e1 = Calloc(p, int); // ever active set
-  int *e2 = Calloc(p, int); // strong set
-  double *R = Calloc(m*n, double); // residual matrix
-  double *sumResid = Calloc(m, double);
+  int *e1 = R_Calloc(p, int); // ever active set
+  int *e2 = R_Calloc(p, int); // strong set
+  double *R = R_Calloc(m*n, double); // residual matrix
+  double *sumResid = R_Calloc(m, double);
   loss[0] = 0;
   for(k = 0; k < m; k++) sumResid[k] = 0;
   for(i = 0; i < n; i++) {
@@ -813,7 +813,7 @@ RcppExport SEXP cdfit_mgaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
       loss[0] += pow(Y.at(k, i), 2);
     } 
   }
-  double *xTR = Calloc(m, double);
+  double *xTR = R_Calloc(m, double);
   thresh = eps * loss[0] / n;
   
   // set up lambda
@@ -856,7 +856,7 @@ RcppExport SEXP cdfit_mgaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
       }
       if (nv > dfmax) {
         for (int ll=l; ll<L; ll++) iter[ll] = NA_INTEGER;
-        Free(a); Free(e1); Free(e2); Free(xTR); Free(shift); Free(R); Free(sumResid);
+        R_Free(a); R_Free(e1); R_Free(e2); R_Free(xTR); R_Free(shift); R_Free(R); R_Free(sumResid);
         return List::create(beta, center, scale, lambda, loss, iter, n_reject, Rcpp::wrap(col_idx));
       }
       // strong set
@@ -940,7 +940,7 @@ RcppExport SEXP cdfit_mgaussian_ssr(SEXP X_, SEXP y_, SEXP row_idx_,
     }
   }
   
-  Free(a); Free(e1); Free(e2); Free(xTR); Free(shift); Free(R); Free(sumResid);
+  R_Free(a); R_Free(e1); R_Free(e2); R_Free(xTR); R_Free(shift); R_Free(R); R_Free(sumResid);
   //ProfilerStop();
   return List::create(beta, center, scale, lambda, loss, iter, n_reject, Rcpp::wrap(col_idx));
 }


### PR DESCRIPTION
Dear Chuyi, dear biglasso team,

Your CRAN package biglasso uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, we can prefix each #include <Rcpp.h> with STRICT_R_HEADERS, or we can also define it in src/Makevars* for a more minimal changeset via -DSTRICT_R_HEADERS,  or as I currently do add in the Rcpp headers.  Defining it means `Calloc()` and `Free()` are no longer "visible" as the more defensively named `R_Calloc()` and `R_Free()` are preferred.  The simple PR just renames them in four files.   

We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it.  So if you really do not want the change you can prevent it -- see these lines in Rcpp for details: 
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Please don't hesitate to ask (here, at https://github.com/RcppCore/Rcpp/issues/1158, or via email) if you have any questions.

Many thanks for your help, and I hope you continue to find Rcpp helpful. 