### PR TITLE
cv.biglasso enhancements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ Suggests:
     survival,
     knitr,
     rmarkdown
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # biglasso 1.4-1
 * changed R package maintainer to Chuyi Wang (wwaa0208@gmail.com)
 * fixed bugs
+* Add 'auc', 'class' options to cv.biglasso eval.metric
+* predict.cv now predicts standard error over CV folds by default; set 'grouped' argument to FALSE for old behaviour.
+* predict.cv.biglasso accepts 'lambda.min', 'lambda.1se' argument, similar to predict.cv.glmnet()
 
 # biglasso 1.4-0
 * adaptive screening methods were implemented and set as default when applicable

--- a/R/cv.biglasso.R
+++ b/R/cv.biglasso.R
@@ -1,8 +1,8 @@
 #' Cross-validation for biglasso
-#' 
+#'
 #' Perform k-fold cross validation for penalized regression models over a grid
 #' of values for the regularization parameter lambda.
-#' 
+#'
 #' The function calls \code{biglasso} \code{nfolds} times, each time leaving
 #' out 1/\code{nfolds} of the data.  The cross-validation error is based on the
 #' residual sum of squares when \code{family="gaussian"} and the binomial
@@ -10,7 +10,7 @@
 #' \code{cv.biglasso} inherits class \code{\link[ncvreg]{cv.ncvreg}}.  So S3
 #' functions such as \code{"summary", "plot"} can be directly applied to the
 #' \code{cv.biglasso} object.
-#' 
+#'
 #' @param X The design matrix, without an intercept, as in
 #' \code{\link{biglasso}}.
 #' @param y The response vector, as in \code{biglasso}.
@@ -21,12 +21,18 @@
 #' are not supported yet.
 #' @param eval.metric The evaluation metric for the cross-validated error and
 #' for choosing optimal \code{lambda}. "default" for linear regression is MSE
-#' (mean squared error), for logistic regression is misclassification error.
+#' (mean squared error), for logistic regression is binomial deviance.
 #' "MAPE", for linear regression only, is the Mean Absolute Percentage Error.
-#' @param ncores The number of cores to use for parallel execution across a
-#' cluster created by the \code{parallel} package. (This is different from
-#' \code{ncores} in \code{\link{biglasso}}, which is the number of OpenMP
-#' threads.)
+#' "auc", for binary classification, is the area under the receiver operating
+#' characteristic curve (ROC).
+#' "class", for binary classification, gives the misclassification error.
+#' @param ncores The number of cores to use for parallel execution of the
+#' cross-validation folds, run on a cluster created by the \code{parallel}
+#' package. (This is also supplied to the \code{ncores} argument in
+#' \code{\link{biglasso}}, which is the number of OpenMP threads, but only for
+#' the first call of \code{\link{biglasso}} that is  run on the entire data. The
+#' individual calls of \code{\link{biglasso}} for the CV folds are run without
+#' the \code{ncores} argument.)
 #' @param ... Additional arguments to \code{biglasso}.
 #' @param nfolds The number of cross-validation folds.  Default is 5.
 #' @param seed The seed of the random number generator in order to obtain
@@ -35,6 +41,9 @@
 #' observations are randomly assigned by \code{cv.biglasso}.
 #' @param trace If set to TRUE, cv.biglasso will inform the user of its
 #' progress by announcing the beginning of each CV fold.  Default is FALSE.
+#' @param grouped Whether to calculate CV standard error (\code{cvse}) over
+#' CV folds (\code{TRUE}), or over all cross-validated predictions. Ignored
+#' when \code{eval.metric} is 'auc'.
 #' @return An object with S3 class \code{"cv.biglasso"} which inherits from
 #' class \code{"cv.ncvreg"}.  The following variables are contained in the
 #' class (adopted from \code{\link[ncvreg]{cv.ncvreg}}).  \item{cve}{The error
@@ -50,7 +59,7 @@
 #' prediction error for each value of \code{lambda}.} \item{cv.ind}{Same as
 #' above.}
 #' @author Yaohui Zeng and Patrick Breheny
-#' 
+#'
 #' Maintainer: Yaohui Zeng <yaohui.zeng@@gmail.com>
 #' @seealso \code{\link{biglasso}}, \code{\link{plot.cv.biglasso}},
 #' \code{\link{summary.cv.biglasso}}, \code{\link{setupX}}
@@ -61,26 +70,26 @@
 #' X <- colon$X
 #' y <- colon$y
 #' X.bm <- as.big.matrix(X)
-#' 
+#'
 #' ## logistic regression
 #' cvfit <- cv.biglasso(X.bm, y, family = 'binomial', seed = 1234, ncores = 2)
 #' par(mfrow = c(2, 2))
 #' plot(cvfit, type = 'all')
 #' summary(cvfit)
 #' }
-#' 
+#'
 #' @export cv.biglasso
-#' 
-cv.biglasso <- function(X, y, row.idx = 1:nrow(X), 
+#'
+cv.biglasso <- function(X, y, row.idx = 1:nrow(X),
                         family = c("gaussian", "binomial", "cox", "mgaussian"),
-                        eval.metric = c("default", "MAPE"),
+                        eval.metric = c("default", "MAPE", "auc", "class"),
                         ncores = parallel::detectCores(), ...,
-                        nfolds = 5, seed, cv.ind, trace = FALSE) {
-  
+                        nfolds = 5, seed, cv.ind, trace = FALSE, grouped = TRUE) {
+
   family <- match.arg(family)
   if(!family %in% c("gaussian", "binomial")) stop("CV method for this family not supported yet.")
-  
-  #TODO: 
+
+  #TODO:
   #   system-specific parallel: Windows parLapply; others: mclapply
   eval.metric <- match.arg(eval.metric)
 
@@ -89,35 +98,41 @@ cv.biglasso <- function(X, y, row.idx = 1:nrow(X),
     cat("The number of cores specified (", ncores, ") is larger than the number of avaiable cores (", max.cores, "). Use ", max.cores, " cores instead! \n", sep = "")
     ncores = max.cores
   }
-  
+
   fit <- biglasso(X = X, y = y, row.idx = row.idx, family = family, ncores = ncores, ...)
-  n <- fit$n
-  E <- Y <- matrix(NA, nrow=n, ncol=length(fit$lambda))
+  if (eval.metric == "auc") grouped <- TRUE
+
+  E <- matrix(Inf, nrow=if (grouped) nfolds else fit$n, ncol=length(fit$lambda))
   # y <- fit$y # this would cause error if eval.metric == "MAPE"
-  
+
   if (fit$family == 'binomial') {
-    PE <- E
+    PE <- matrix(NA, nrow=fit$n, ncol=length(fit$lambda))
   }
 
   if (!missing(seed)) set.seed(seed)
+
+  n <- fit$n
   if (missing(cv.ind)) {
-    if (fit$family=="binomial" & (min(table(y)) > nfolds)) {
+    if (fit$family=="binomial" && (min(table(y)) > nfolds)) {
       ind1 <- which(y==1)
       ind0 <- which(y==0)
       n1 <- length(ind1)
       n0 <- length(ind0)
-      cv.ind1 <- ceiling(sample(1:n1)/n1*nfolds)
-      cv.ind0 <- ceiling(sample(1:n0)/n0*nfolds)
+      cv.ind1 <- ceiling(sample(n1)/n1*nfolds)
+      cv.ind0 <- ceiling(sample(n0)/n0*nfolds)
       cv.ind <- numeric(n)
       cv.ind[y==1] <- cv.ind1
       cv.ind[y==0] <- cv.ind0
     } else {
-      cv.ind <- ceiling(sample(1:n)/n*nfolds)
+      cv.ind <- ceiling(sample(n)/n*nfolds)
     }
   }
-  
+
   cv.args <- list(...)
   cv.args$lambda <- fit$lambda
+  cv.args$family <- family
+
+
 
   parallel <- FALSE
   if (ncores > 1) {
@@ -126,11 +141,11 @@ cv.biglasso <- function(X, y, row.idx = 1:nrow(X),
     parallel <- TRUE
     ## pass the descriptor info to each cluster ##
     xdesc <- bigmemory::describe(X)
-    parallel::clusterExport(cluster, c("cv.ind", "xdesc", "y", "cv.args", 
-                                       "parallel", "eval.metric"), 
+    parallel::clusterExport(cluster, c("cv.ind", "xdesc", "y", "cv.args",
+                                       "parallel", "eval.metric"),
                             envir=environment())
     parallel::clusterCall(cluster, function() {
-     
+
       require(biglasso)
       # require(bigmemory)
       # require(Matrix)
@@ -139,38 +154,44 @@ cv.biglasso <- function(X, y, row.idx = 1:nrow(X),
       # source("~/GitHub/biglasso/R/predict.R")
       # source("~/GitHub/biglasso/R/loss.R")
     })
-    fold.results <- parallel::parLapply(cl = cluster, X = 1:nfolds, fun = cvf, XX = xdesc, 
-                                        y = y, eval.metric = eval.metric, 
-                                        cv.ind = cv.ind, cv.args = cv.args, 
+    fold.results <- parallel::parLapply(cl = cluster, X = seq_len(nfolds), fun = cvf, XX = xdesc,
+                                        y = y, eval.metric = eval.metric,
+                                        cv.ind = cv.ind, cv.args = cv.args, grouped = grouped,
                                         parallel = parallel)
     parallel::stopCluster(cluster)
   }
 
-  for (i in 1:nfolds) {
+  result.ind <- if (grouped) seq_len(nfolds) else cv.ind
+  for (i in seq_len(nfolds)) {
     if (parallel) {
       res <- fold.results[[i]]
     } else {
       if (trace) cat("Starting CV fold #", i, sep="", "\n")
-      res <- cvf(i, X, y, eval.metric, cv.ind, cv.args)
+      res <- cvf(i, X, y, eval.metric, cv.ind, cv.args, grouped = grouped)
     }
-    E[cv.ind == i, 1:res$nl] <- res$loss
-    if (fit$family == "binomial") PE[cv.ind == i, 1:res$nl] <- res$pe
-    Y[cv.ind == i, 1:res$nl] <- res$yhat
+    E[result.ind == i, match(res$ls, fit$lambda)] <- res$loss
+    if (fit$family == "binomial") PE[cv.ind == i, match(res$ls, fit$lambda)] <- res$pe
   }
 
   ## Eliminate saturated lambda values, if any
-  ind <- which(apply(is.finite(E), 2, all))
+  # deliberately do *not* eliminate NAs, which can occur when AUC breaks
+  ind <- which(apply(!is.infinite(E), 2, all))
   E <- E[,ind]
-  Y <- Y[,ind]
   lambda <- fit$lambda[ind]
-  
+
   ## Return
-  cve <- apply(E, 2, mean)
-  cvse <- apply(E, 2, sd) / sqrt(n)
+  if (grouped) {
+    foldweights <- sapply(seq_len(nfolds), function(i) sum(cv.ind == i))
+    cve <- apply(E, 2, weighted.mean, w = foldweights, na.rm = TRUE)  # na.rm only relevant for 'auc' case
+    cvse <- sqrt(apply(sweep(E, 2, cve)^2, 2, weighted.mean, w = foldweights, na.rm = TRUE) / (nfolds - 1))
+  } else {
+    cve <- apply(E, 2, mean)
+    cvse <- apply(E, 2, sd) / sqrt(n)
+  }
   min <- which.min(cve)
 
   val <- list(cve=cve, cvse=cvse, lambda=lambda, fit=fit, min=min, lambda.min=lambda[min],
-              null.dev=mean(loss.biglasso(y, rep(mean(y), n), 
+              null.dev=mean(loss.biglasso(y, rep(mean(y), n),
                                           fit$family, eval.metric = eval.metric)),
               cv.ind = cv.ind,
               eval.metric = eval.metric)
@@ -178,11 +199,10 @@ cv.biglasso <- function(X, y, row.idx = 1:nrow(X),
     pe <- apply(PE, 2, mean)
     val$pe <- pe[is.finite(pe)]
   }
-  # if (returnY) val$Y <- Y
   structure(val, class=c("cv.biglasso", "cv.ncvreg"))
 }
 
-cvf <- function(i, XX, y, eval.metric, cv.ind, cv.args, parallel= FALSE) {
+cvf <- function(i, XX, y, eval.metric, cv.ind, cv.args, grouped, parallel= FALSE) {
   # reference to the big.matrix by descriptor info
   if (parallel) {
     XX <- attach.big.matrix(XX)
@@ -199,9 +219,10 @@ cvf <- function(i, XX, y, eval.metric, cv.ind, cv.args, parallel= FALSE) {
   y2 <- y[cv.ind==i]
   yhat <- matrix(predict(fit.i, XX, row.idx = idx.test, type="response"), length(y2))
 
-  loss <- loss.biglasso(y2, yhat, fit.i$family, eval.metric = eval.metric)
+  loss <- loss.biglasso(y2, yhat, fit.i$family, eval.metric = eval.metric, grouped = grouped)
 
-  pe <- if (fit.i$family=="binomial") {(yhat < 0.5) == y2} else NULL
-  list(loss=loss, pe=pe, nl=length(fit.i$lambda), yhat=yhat)
+  pe <- if (fit.i$family=="binomial") (yhat <= 0.5) == y2
+
+  list(loss=loss, pe=pe, ls=fit.i$lambda, yhat=yhat)
 }
 

--- a/R/loss.R
+++ b/R/loss.R
@@ -74,7 +74,7 @@ loss.biglasso <- function(y, yhat, family, eval.metric, grouped = TRUE) {
       if (t0.len == 0 || t1.len == 0) {
         # This happens when we have a bad CV split.
         # In this case the AUC is not defined. We return NA to ignore this fold.
-        val <- rep(NA_reals_, ncol(yhat))
+        val <- rep(NA_real_, ncol(yhat))
       } else {
         val <- apply(yhat, 2, function(yhcol) {
           (mean(rank(yhcol, ties.method = "average")[t1]) - (t1.len + 1) / 2) /

--- a/R/loss.R
+++ b/R/loss.R
@@ -1,24 +1,32 @@
 #' Internal biglasso functions
-#' 
+#'
 #' Internal biglasso functions
-#' 
-#' These are not intended for use by users.\code{loss.biglasso} calculates the 
+#'
+#' These are not intended for use by users.\code{loss.biglasso} calculates the
 #' value of the loss function for the given predictions (used for cross-validation).
-#' 
-#' @param y The observed response vector. 
+#'
+#' @param y The observed response vector.
 #' @param yhat The predicted response vector.
 #' @param family Either "gaussian" or "binomial", depending on the response.
 #' @param eval.metric The evaluation metric for the cross-validated error and
 #' for choosing optimal \code{lambda}. "default" for linear regression is MSE
 #' (mean squared error), for logistic regression is misclassification error.
 #' "MAPE", for linear regression only, is the Mean Absolute Percentage Error.
+#' "auc", for logistic regression, is the area under the receiver operating
+#' characteristic curve (ROC).
+#' @param grouped Whether to calculate loss for the entire CV fold
+#' (\code{TRUE}), or for predictions individually. Must be \code{TRUE} when
+#' \code{eval.metric} is 'auc'.
 #' @author Yaohui Zeng and Patrick Breheny
-#' 
+#'
 #' Maintainer: Yaohui Zeng <yaohui.zeng@@gmail.com>
 #' @keywords internal
 #'
-loss.biglasso <- function(y, yhat, family, eval.metric) {
+loss.biglasso <- function(y, yhat, family, eval.metric, grouped = TRUE) {
   n <- length(y)
+  if (!is.matrix(yhat)) {
+    yhat <- as.matrix(yhat)
+  }
   if (family=="gaussian") {
     if (eval.metric == 'default') {
       val <- (y-yhat)^2
@@ -31,20 +39,62 @@ loss.biglasso <- function(y, yhat, family, eval.metric) {
     if (eval.metric == 'default') {
       yhat[yhat < 0.00001] <- 0.00001
       yhat[yhat > 0.99999] <- 0.99999
-      if (is.matrix(yhat)) {
-        val <- matrix(NA, nrow=nrow(yhat), ncol=ncol(yhat))
-        if (sum(y==1)) val[y==1,] <- -2*log(yhat[y==1, , drop=FALSE])
-        if (sum(y==0)) val[y==0,] <- -2*log(1-yhat[y==0, , drop=FALSE])
+      val <- matrix(NA, nrow=nrow(yhat), ncol=ncol(yhat))
+      if (sum(y==1)) val[y==1,] <- -2*log(yhat[y==1, , drop=FALSE])
+      if (sum(y==0)) val[y==0,] <- -2*log(1-yhat[y==0, , drop=FALSE])
+    } else if (eval.metric == 'auc') {
+      if (!grouped) stop("eval.metric == 'auc' needs grouped == TRUE")
+      grouped <- FALSE  # ironically! Because grouping won't be necessary in the end.
+      # AUC estimator according to e.g. 10.1007/978-3-540-74976-9_8:
+      # D0: indices of negative examples
+      # D1: indices of positive examples
+      # (1) > auc <- 0
+      # (2) > for (t0 in D0) for (t1 in D1)
+      # (3) >   auc <- auc + (yhat[t0] < yhat[t1])
+      # (4) > auc <- auc / (length(D0) * length(D1))
+      # Simplify (3):
+      # (3) > auc <- auc + sum(yhat[D0] < yhat[t1])
+      # ...
+      # (3) > auc <- auc + sum(yhat < yhat[t1]) - sum(yhat[D1] < yhat[t1])
+      # ...
+      # (3) > auc <- auc + rank(yhat)[t1] - length(D1) - sum(yhat[D1] < yhat[t1])
+      # Recognize that 'for (t1 in D1) auc <- auc + rank(yhat)[t1]' vectorizes,
+      # and that 'for (t1 in D1) auc <- auc - length(D1) - sum(yhat[D1]<yhat[t1])'
+      # is 'auc - length(D1) * (length(D1) + 1) / 2'.
+      # This leads to the expression
+      # > auc <- (sum(rank(yhat)[t1]) - length(D1) * (length(D1) + 1) / 2) /
+      # >        (length(D0) * length(D1))
+      # Which further simplifies to:
+      # > auc <- (mean(rank(yhat)[t1]) - (length(D1) + 1) / 2) / length(D0)
+      # In case of ties we calculate the expected value over randomly broken
+      # ties, which corresponds to 'ties.method = "average"'.
+      t1 <- y == 1
+      t1.len <- sum(t1)
+      t0.len <- n - t1.len
+      if (t0.len == 0 || t1.len == 0) {
+        # This happens when we have a bad CV split.
+        # In this case the AUC is not defined. We return NA to ignore this fold.
+        val <- rep(NA_reals_, ncol(yhat))
       } else {
-        val <- numeric(length(y))
-        if (sum(y==1)) val[y==1] <- -2*log(yhat[y==1])
-        if (sum(y==0)) val[y==0] <- -2*log(1-yhat[y==0])
+        val <- apply(yhat, 2, function(yhcol) {
+          (mean(rank(yhcol, ties.method = "average")[t1]) - (t1.len + 1) / 2) /
+            t0.len
+        })
       }
+    } else if (eval.metric == 'class') {
+      yhat.class <- yhat > 0.5
+      val <- yhat.class != y
+      mode(val) <- "numeric"
+    } else {
+      stop(sprintf("eval.metric %s not supported for family %s.", eval.metric, family))
     }
   } else if (family=="poisson") {
     yly <- y*log(y)
     yly[y==0] <- 0
     val <- 2*(yly - y + yhat - y*log(yhat))
+  }
+  if (grouped) {
+    val <- apply(val, 2, mean)
   }
   val
 }

--- a/R/predict.cv.R
+++ b/R/predict.cv.R
@@ -1,11 +1,11 @@
 #' Model predictions based on a fitted \code{\link{cv.biglasso}} object
-#' 
+#'
 #' Extract predictions from a fitted \code{\link{cv.biglasso}} object.
-#' 
+#'
 #' @name predict.cv.biglasso
 #' @rdname predict.cv.biglasso
 #' @method predict cv.biglasso
-#' 
+#'
 #' @param object A fitted \code{"cv.biglasso"} model object.
 #' @param X Matrix of values at which predictions are to be made. It must be a
 #' \code{\link[bigmemory]{big.matrix}} object. Not used for
@@ -22,7 +22,10 @@
 #' \code{lambda}.
 #' @param lambda Values of the regularization parameter \code{lambda} at which
 #' predictions are requested.  The default value is the one corresponding to
-#' the minimum cross-validation error.
+#' the minimum cross-validation error. Accepted values are also the strings
+#' "lambda.min" (\code{lambda} of minimum cross-validation error) and
+#' "lambda.1se" (Largest value of \code{lambda} for which the cross-validation
+#' error was at most one standard error larger than the minimum.).
 #' @param which Indices of the penalty parameter \code{lambda} at which
 #' predictions are requested. The default value is the index of lambda
 #' corresponding to lambda.min.  Note: this is overridden if \code{lambda} is
@@ -30,7 +33,7 @@
 #' @param \dots Not used.
 #' @return The object returned depends on \code{type}.
 #' @author Yaohui Zeng and Patrick Breheny
-#' 
+#'
 #' Maintainer: Yaohui Zeng <yaohui.zeng@@gmail.com>
 #' @seealso \code{\link{biglasso}}, \code{\link{cv.biglasso}}
 #' @keywords models regression
@@ -48,23 +51,28 @@
 #' predict(cvfit, X.bm, type = "response")
 #' predict(cvfit, X.bm, type = "link")
 #' predict(cvfit, X.bm, type = "class")
+#' predict(cvfit, X.bm, lambda = "lambda.1se")
 #' }
 #' @export
-#' 
+#'
 predict.cv.biglasso <- function(object, X, row.idx = 1:nrow(X),
                                 type = c("link","response","class",
-                                         "coefficients","vars","nvars"), 
+                                         "coefficients","vars","nvars"),
                                 lambda = object$lambda.min,
                                 which = object$min, ...) {
+  if (is.character(lambda)) {
+    lambda <- match.arg(lambda, c("lambda.min", "lambda.1se"))
+    lambda <- object[[lambda]]
+  }
   type <- match.arg(type)
-  predict.biglasso(object$fit, X = X, row.idx = row.idx, type = type, 
+  predict.biglasso(object$fit, X = X, row.idx = row.idx, type = type,
                    lambda = lambda, which = which, ...)
 }
 
 #' @method coef cv.biglasso
 #' @rdname predict.cv.biglasso
 #' @export
-#' 
+#'
 coef.cv.biglasso <- function(object, lambda = object$lambda.min, which = object$min, ...) {
   coef.biglasso(object$fit, lambda = lambda, which = which, ...)
 }

--- a/man/cv.biglasso.Rd
+++ b/man/cv.biglasso.Rd
@@ -76,10 +76,12 @@ values along which the cross-validation error was calculated.}
 \item{fit}{The fitted \code{biglasso} object for the whole data.}
 \item{min}{The index of \code{lambda} corresponding to \code{lambda.min}.}
 \item{lambda.min}{The value of \code{lambda} with the minimum
-cross-validation error.} \item{null.dev}{The deviance for the intercept-only
-model.} \item{pe}{If \code{family="binomial"}, the cross-validation
-prediction error for each value of \code{lambda}.} \item{cv.ind}{Same as
-above.}
+cross-validation error.} \item{lambda.1se}{The largest value of \code{lambda}
+for which the cross-validation error is at most one standard error larger
+than the minimum cross-validation error.} \item{null.dev}{The deviance for
+the intercept-only model.} \item{pe}{If \code{family="binomial"}, the
+cross-validation prediction error for each value of \code{lambda}.}
+\item{cv.ind}{Same as above.}
 }
 \description{
 Perform k-fold cross validation for penalized regression models over a grid

--- a/man/cv.biglasso.Rd
+++ b/man/cv.biglasso.Rd
@@ -9,13 +9,14 @@ cv.biglasso(
   y,
   row.idx = 1:nrow(X),
   family = c("gaussian", "binomial", "cox", "mgaussian"),
-  eval.metric = c("default", "MAPE"),
+  eval.metric = c("default", "MAPE", "auc", "class"),
   ncores = parallel::detectCores(),
   ...,
   nfolds = 5,
   seed,
   cv.ind,
-  trace = FALSE
+  trace = FALSE,
+  grouped = TRUE
 )
 }
 \arguments{
@@ -33,13 +34,19 @@ are not supported yet.}
 
 \item{eval.metric}{The evaluation metric for the cross-validated error and
 for choosing optimal \code{lambda}. "default" for linear regression is MSE
-(mean squared error), for logistic regression is misclassification error.
-"MAPE", for linear regression only, is the Mean Absolute Percentage Error.}
+(mean squared error), for logistic regression is binomial deviance.
+"MAPE", for linear regression only, is the Mean Absolute Percentage Error.
+"auc", for binary classification, is the area under the receiver operating
+characteristic curve (ROC).
+"class", for binary classification, gives the misclassification error.}
 
-\item{ncores}{The number of cores to use for parallel execution across a
-cluster created by the \code{parallel} package. (This is different from
-\code{ncores} in \code{\link{biglasso}}, which is the number of OpenMP
-threads.)}
+\item{ncores}{The number of cores to use for parallel execution of the
+cross-validation folds, run on a cluster created by the \code{parallel}
+package. (This is also supplied to the \code{ncores} argument in
+\code{\link{biglasso}}, which is the number of OpenMP threads, but only for
+the first call of \code{\link{biglasso}} that is  run on the entire data. The
+individual calls of \code{\link{biglasso}} for the CV folds are run without
+the \code{ncores} argument.)}
 
 \item{...}{Additional arguments to \code{biglasso}.}
 
@@ -53,6 +60,10 @@ observations are randomly assigned by \code{cv.biglasso}.}
 
 \item{trace}{If set to TRUE, cv.biglasso will inform the user of its
 progress by announcing the beginning of each CV fold.  Default is FALSE.}
+
+\item{grouped}{Whether to calculate CV standard error (\code{cvse}) over
+CV folds (\code{TRUE}), or over all cross-validated predictions. Ignored
+when \code{eval.metric} is 'auc'.}
 }
 \value{
 An object with S3 class \code{"cv.biglasso"} which inherits from

--- a/man/loss.biglasso.Rd
+++ b/man/loss.biglasso.Rd
@@ -4,7 +4,7 @@
 \alias{loss.biglasso}
 \title{Internal biglasso functions}
 \usage{
-loss.biglasso(y, yhat, family, eval.metric)
+loss.biglasso(y, yhat, family, eval.metric, grouped = TRUE)
 }
 \arguments{
 \item{y}{The observed response vector.}
@@ -16,13 +16,19 @@ loss.biglasso(y, yhat, family, eval.metric)
 \item{eval.metric}{The evaluation metric for the cross-validated error and
 for choosing optimal \code{lambda}. "default" for linear regression is MSE
 (mean squared error), for logistic regression is misclassification error.
-"MAPE", for linear regression only, is the Mean Absolute Percentage Error.}
+"MAPE", for linear regression only, is the Mean Absolute Percentage Error.
+"auc", for logistic regression, is the area under the receiver operating
+characteristic curve (ROC).}
+
+\item{grouped}{Whether to calculate loss for the entire CV fold
+(\code{TRUE}), or for predictions individually. Must be \code{TRUE} when
+\code{eval.metric} is 'auc'.}
 }
 \description{
 Internal biglasso functions
 }
 \details{
-These are not intended for use by users.\code{loss.biglasso} calculates the 
+These are not intended for use by users.\code{loss.biglasso} calculates the
 value of the loss function for the given predictions (used for cross-validation).
 }
 \author{

--- a/man/predict.cv.biglasso.Rd
+++ b/man/predict.cv.biglasso.Rd
@@ -38,7 +38,10 @@ names of the nonzero variables at each value of \code{lambda};
 
 \item{lambda}{Values of the regularization parameter \code{lambda} at which
 predictions are requested.  The default value is the one corresponding to
-the minimum cross-validation error.}
+the minimum cross-validation error. Accepted values are also the strings
+"lambda.min" (\code{lambda} of minimum cross-validation error) and
+"lambda.1se" (Largest value of \code{lambda} for which the cross-validation
+error was at most one standard error larger than the minimum.).}
 
 \item{which}{Indices of the penalty parameter \code{lambda} at which
 predictions are requested. The default value is the index of lambda
@@ -67,6 +70,7 @@ coef[which(coef != 0)]
 predict(cvfit, X.bm, type = "response")
 predict(cvfit, X.bm, type = "link")
 predict(cvfit, X.bm, type = "class")
+predict(cvfit, X.bm, lambda = "lambda.1se")
 }
 }
 \seealso{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // get_eta
 RcppExport SEXP get_eta(SEXP xP, SEXP row_idx_, SEXP beta, SEXP idx_p, SEXP idx_l);
 RcppExport SEXP _biglasso_get_eta(SEXP xPSEXP, SEXP row_idx_SEXP, SEXP betaSEXP, SEXP idx_pSEXP, SEXP idx_lSEXP) {

--- a/tests/testthat/test_biglasso_logistic.R
+++ b/tests/testthat/test_biglasso_logistic.R
@@ -25,6 +25,36 @@ fit.ssr.mm <- biglasso(X.bm, y, family = 'binomial', eps = eps, alg.logistic = '
 fit.hybrid <- biglasso(X.bm, y, family = 'binomial', eps = eps, screen = 'Hybrid', lambda.min = 0)
 fit.adaptive <- biglasso(X.bm, y, family = 'binomial', eps = eps, screen = 'Adaptive', lambda.min = 0)
 
+
+cv.ind <- rep(1:10, 10)
+
+cv.default <- cv.biglasso(X.bm, y, family = 'binomial',
+  eps = eps, nfolds = 10, cv.ind = cv.ind, eval.metric = "default", ncores = 1)
+cv.default.ungrouped <- cv.biglasso(X.bm, y, family = 'binomial',
+  eps = eps, nfolds = 10, cv.ind = cv.ind, eval.metric = "default", ncores = 1, grouped = FALSE)
+
+cv.auc <- cv.biglasso(X.bm, y, eval.metric = "auc", family = 'binomial',
+  eps = eps, nfolds = 10, cv.ind = cv.ind, ncores = 1)
+
+cv.class <- cv.biglasso(X.bm, y, eval.metric = "class", family = 'binomial',
+  eps = eps, nfolds = 10, cv.ind = cv.ind, ncores = 1)
+cv.class.ungrouped <- cv.biglasso(X.bm, y, eval.metric = "class", family = 'binomial',
+  eps = eps, nfolds = 10, cv.ind = cv.ind, ncores = 1, grouped = FALSE)
+
+cv.glmnet.default <- cv.glmnet(X, y, family = 'binomial',
+  lambda = cv.default$lambda, nfolds = 10, foldid = cv.ind, thresh = eps)
+cv.glmnet.default.ungrouped <- cv.glmnet(X, y, family = 'binomial',
+  lambda = cv.default$lambda, nfolds = 10, foldid = cv.ind, thresh = eps, grouped = FALSE)
+
+cv.glmnet.auc <- cv.glmnet(X, y, family = 'binomial', type.measure = "auc",
+  lambda = cv.default$lambda, nfolds = 10, foldid = cv.ind, thresh = eps)
+
+cv.glmnet.class <- cv.glmnet(X, y, family = 'binomial', type.measure = "class",
+  lambda = cv.default$lambda, nfolds = 10, foldid = cv.ind, thresh = eps)
+cv.glmnet.class.ungrouped <- cv.glmnet(X, y, family = 'binomial', type.measure = "class",
+  lambda = cv.default$lambda, nfolds = 10, foldid = cv.ind, thresh = eps, grouped = FALSE)
+
+
 test_that("Test against MLE: ",{
   expect_equal(as.numeric(beta), as.numeric(fit.ssr$beta[, 100]), tolerance = tolerance)
   expect_equal(as.numeric(fit.ssr$beta[, 100]), as.numeric(fit.hybrid$beta[, 100]), tolerance = tolerance)
@@ -37,4 +67,39 @@ test_that("Test against glmnet: ",{
   expect_equal(as.numeric(fit.glm$beta), as.numeric(fit.ssr.mm$beta[-1, ]), tolerance = tolerance)
   expect_equal(as.numeric(fit.glm$beta), as.numeric(fit.hybrid$beta[-1, ]), tolerance = tolerance)
   expect_equal(as.numeric(fit.glm$beta), as.numeric(fit.adaptive$beta[-1, ]), tolerance = tolerance)
+})
+
+test_that("Test CV against glmnet: ",{
+  # default
+  expect_equal(cv.default$cve, cv.glmnet.default$cvm, tolerance = tolerance)
+  expect_equal(cv.default$cvse, cv.glmnet.default$cvsd, tolerance = tolerance)
+  expect_equal(cv.default.ungrouped$cve, cv.glmnet.default$cvm, tolerance = tolerance)  # comparing grouped vs. ungrouped on purpose here
+  expect_equal(cv.default.ungrouped$cvse, unname(cv.glmnet.default.ungrouped$cvsd), tolerance = tolerance)
+  expect_equal(cv.default$lambda.min, cv.glmnet.default$lambda.min)
+  expect_equal(cv.default.ungrouped$lambda.min, cv.glmnet.default.ungrouped$lambda.min)
+  expect_equal(cv.default.ungrouped$lambda.1se, cv.glmnet.default.ungrouped$lambda.1se)
+
+  # auc
+  expect_equal(cv.auc$cve, cv.glmnet.auc$cvm, tolerance = tolerance)
+  expect_equal(cv.auc$cvse, cv.glmnet.auc$cvsd, tolerance = tolerance)
+  expect_equal(cv.auc$lambda.min, cv.glmnet.auc$lambda.min)
+  expect_equal(cv.auc$lambda.1se, cv.glmnet.auc$lambda.1se)
+
+  # class
+  expect_equal(cv.class$cve, cv.glmnet.class$cvm, tolerance = tolerance)
+  expect_equal(cv.class$cvse, cv.glmnet.class$cvsd, tolerance = tolerance)
+  expect_equal(cv.class.ungrouped$cve, cv.glmnet.class$cvm, tolerance = tolerance)
+  expect_equal(cv.class.ungrouped$cvse, unname(cv.glmnet.class.ungrouped$cvsd), tolerance = tolerance)
+  expect_equal(cv.class$lambda.min, cv.glmnet.class$lambda.min)
+  expect_equal(cv.class.ungrouped$lambda.min, cv.glmnet.class.ungrouped$lambda.min)
+  expect_equal(cv.class.ungrouped$lambda.1se, cv.glmnet.class.ungrouped$lambda.1se)
+
+  # predictions with special lambda-values
+  lminpred <- predict(cv.default, X.bm, lambda = "lambda.min")
+  lminpred.glmnet <- predict(cv.glmnet.default, X, s = "lambda.min")
+  expect_equal(unname(as.matrix(lminpred)), unname(lminpred.glmnet), tolerance = tolerance)
+
+  l1sepred <- predict(cv.default, X.bm, lambda = "lambda.1se")
+  l1sepred.glmnet <- predict(cv.glmnet.default, X, s = "lambda.1se")
+  expect_equal(unname(as.matrix(l1sepred)), unname(l1sepred.glmnet), tolerance = tolerance)
 })


### PR DESCRIPTION
I had to develop AUC for an internal project and now I'm wondering if you also want to incorporate this in the package. I changed how 'cvse' is calculated: it is now calculated over CV folds only, not over predictions within the folds, just like glmnet does it; this can also be changed with the 'grouped' argument as in glmnet. I also fixed the documentation issue I opened recently. I think these are good changes but I also won't be bitter if you don't want this PR.

* Add 'auc', 'class' options to cv.biglasso eval.metric
* predict.cv now predicts standard error over CV folds by default; set 'grouped' argument to FALSE for old behaviour.
* predict.cv.biglasso accepts 'lambda.min', 'lambda.1se' argument, similar to predict.cv.glmnet()
* documentation fix 
closes #44