### PR TITLE
Incorporating dfmax into biglasso_path()

### DIFF
--- a/R/biglasso_path.R
+++ b/R/biglasso_path.R
@@ -95,7 +95,7 @@
 biglasso_path <- function(X,
                           y,
                           r, 
-                          init=rep(0, ncol(X)),
+                          init = rep(0, ncol(X)),
                           xtx, 
                           penalty = "lasso",
                           lambda,
@@ -103,7 +103,7 @@ biglasso_path <- function(X,
                           gamma, 
                           ncores = 1,
                           max.iter = 1000, 
-                          eps=1e-5,
+                          eps = 1e-5,
                           dfmax = ncol(X)+1,
                           penalty.factor = rep(1, ncol(X)),
                           warn = TRUE,
@@ -161,6 +161,7 @@ biglasso_path <- function(X,
                  alpha,
                  gamma, 
                  eps,
+                 as.integer(dfmax),
                  as.integer(max.iter),
                  penalty.factor,
                  as.integer(ncores),
@@ -173,6 +174,13 @@ biglasso_path <- function(X,
   loss <- res[[2]]
   iter <- res[[3]]
   resid <- res[[4]] # TODO: think about whether I need to add this in 
+  
+  ind <- !is.na(iter)
+  b <- b[, ind, drop = FALSE]
+  loss <- loss[ind]
+  iter <- iter[ind]
+  resid <- resid[ind]
+  lambda <- lambda[ind]
   
   if (output.time) {
     cat("\nEnd biglasso: ", format(Sys.time()), '\n')
@@ -193,7 +201,7 @@ biglasso_path <- function(X,
     resid = resid,
     lambda = lambda,
     penalty = penalty,
-    family = family,
+    family = 'gaussian',
     alpha = alpha,
     loss = loss,
     penalty.factor = penalty.factor,

--- a/inst/tinytest/test_biglasso_path.r
+++ b/inst/tinytest/test_biglasso_path.r
@@ -30,6 +30,14 @@ fit2 <- glmnet(X, y = y, family = "gaussian", lambda = lam,
 
 expect_equivalent(fit1$beta, fit2$beta, tolerance = 0.001)
 
+# confirm that dfmax appropriately stops lambda path
+dfmax <- 25
+fit3 <- biglasso_path(X.bm, y, lambda = lam, xtx = xtx, r = resid,
+                      penalty = "lasso", max.iter = 20000, dfmax = dfmax)
+nvar <- predict(fit3, type = "nvars")
+
+expect_true(max(nvar) <= dfmax)
+
 
 # prostate data ---------------------------
 data(Prostate)

--- a/src/gaussian_simple.cpp
+++ b/src/gaussian_simple.cpp
@@ -173,6 +173,7 @@ RcppExport SEXP cdfit_gaussian_simple_path(SEXP X_,
                                            SEXP alpha_,
                                            SEXP gamma_,
                                            SEXP eps_,
+                                           SEXP dfmax_,
                                            SEXP max_iter_,
                                            SEXP multiplier_, 
                                            SEXP ncore_) {
@@ -189,6 +190,7 @@ RcppExport SEXP cdfit_gaussian_simple_path(SEXP X_,
   int n = xMat->nrow(); // number of observations used for fitting model
   int p = xMat->ncol();
   double eps = REAL(eps_)[0];
+  int dfmax = INTEGER(dfmax_)[0];
   int max_iter = INTEGER(max_iter_)[0];
   double *m = REAL(multiplier_);
   const char *penalty = CHAR(STRING_ELT(penalty_, 0));
@@ -304,6 +306,16 @@ RcppExport SEXP cdfit_gaussian_simple_path(SEXP X_,
     }
     // calculate loss 
     loss[l] = gLoss(r, n);
+    
+    // check dfmax
+    int nv = 0;
+    for (int j=0; j<p; j++) {
+      if (a[j] != 0) nv++;
+    }
+    if (nv > dfmax) {
+      for (int ll=l; ll<L; ll++) INTEGER(iter)[ll] = NA_INTEGER;
+      break;
+    }
   }
   
   // cleanup steps

--- a/src/init.c
+++ b/src/init.c
@@ -15,7 +15,7 @@ extern SEXP cdfit_gaussian_simple_path(SEXP X_, SEXP y_, SEXP r_, SEXP init_,
                                        SEXP xtx_, SEXP penalty_, 
                                        SEXP lambda_, SEXP nlambda_, 
                                        SEXP alpha_, SEXP gamma_, SEXP eps_, 
-                                       SEXP max_iter_, SEXP multiplier_, 
+                                       SEXP dfmax_, SEXP max_iter_, SEXP multiplier_, 
                                        SEXP ncore_);
 
 // Coordinate descent for mgaussian model
@@ -135,7 +135,7 @@ extern SEXP _biglasso_get_eta(SEXP xPSEXP,
 static R_CallMethodDef callMethods[] = {
   //{"sqsum", (DL_FUNC) &sqsum,}
   {"cdfit_gaussian_simple", (DL_FUNC) &cdfit_gaussian_simple, 13},
-  {"cdfit_gaussian_simple_path", (DL_FUNC) &cdfit_gaussian_simple_path, 14},
+  {"cdfit_gaussian_simple_path", (DL_FUNC) &cdfit_gaussian_simple_path, 15},
   {"cdfit_mgaussian_ssr", (DL_FUNC) &cdfit_mgaussian_ssr, 15},
   {"cdfit_mgaussian_ada", (DL_FUNC) &cdfit_mgaussian_ada, 17},
   {"cdfit_cox", (DL_FUNC) &cdfit_cox, 18},


### PR DESCRIPTION
There was a placeholder for the `dfmax` option in `biglasso_path()`, but the functionality was not actually implemented in the C++ code. 